### PR TITLE
Exclude vendor directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,4 +13,5 @@ exclude:
   - Gemfile.lock
   - CNAME
   - bin
+  - vendor
 timezone: Asia/Tokyo


### PR DESCRIPTION
### Issues

- [jekyll serve でエラー](https://github.com/splathon/splathon.github.io/issues/13)

### 内容

vendor ディレクトリ以下を jekyll で見てしまうという個人的な環境問題ではあったが、 vendor 以下に置く人もそれなりにいそうなので、除外リストに追加している。

